### PR TITLE
Remove unused assignment to suppress warning

### DIFF
--- a/lib/registry/registry.rb
+++ b/lib/registry/registry.rb
@@ -35,7 +35,7 @@ class DockerRegistry2::Registry
   end
 
   def ping
-    response = doget '/v2/'
+    doget '/v2/'
   end
 
   def search(query = '')


### PR DESCRIPTION
The variable response is assigned but not used which causes a warning when running minitest: 'warning: assigned but unused variable - response'